### PR TITLE
fix for yml/json extensions

### DIFF
--- a/src/main/java/gogoris/ConvertCommand.java
+++ b/src/main/java/gogoris/ConvertCommand.java
@@ -31,7 +31,7 @@ public class ConvertCommand implements Callable<Void> {
         ResourceAccessor resourceAccessor = new FileSystemResourceAccessor();
         ChangeLogParser parser = null;
         try {
-            parser = ChangeLogParserFactory.getInstance().getParser(FilenameUtils.getExtension(input), resourceAccessor);
+            parser = ChangeLogParserFactory.getInstance().getParser(FilenameUtils.getName(input), resourceAccessor);
             DatabaseChangeLog changeLog = parser
                     .parse(input, new ChangeLogParameters(), resourceAccessor);
 


### PR DESCRIPTION
see https://github.com/liquibase/liquibase/blob/master/liquibase-core/src/main/java/liquibase/parser/core/yaml/YamlParser.java
the string should end with '.yml/yaml' or '.json' (as it extends YamlParser)

